### PR TITLE
Update default version for setup call

### DIFF
--- a/src/esegment.erl
+++ b/src/esegment.erl
@@ -24,7 +24,7 @@
 %%====================================================================
 -spec setup(string()) -> ok.
 setup(WriteKey) ->
-    setup(WriteKey, <<"esegment">>, <<"0.11">>).
+    setup(WriteKey, <<"esegment">>, <<"0.12">>).
 
 -spec setup(string(), binary(), binary()) -> ok.
 setup(WriteKey, AppName, AppVersion) ->


### PR DESCRIPTION
Update setup call to match current version and default context app version, see [here](https://github.com/zeemee/esegment/blob/master/src/esegment.erl#L156).